### PR TITLE
Feature/#17 injesh home param

### DIFF
--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -9,17 +9,17 @@ impl Init for InitStruct {
     fn init(&self, init: &command::Init) -> Result<(), Box<dyn std::error::Error>> {
         let mut  err_flg = 0;
 
-        let home_injesh = format!("{}/.injesh", init.user().home());
+        let user_dirs = init.user();
 
-        match fs::create_dir(format!("{}", home_injesh)) {
+        match fs::create_dir(user_dirs.injesh_home()) {
             Ok(_) => {},
             Err(_) => err_flg += 1
         }
-        match fs::create_dir(format!("{}/images", home_injesh)) {
+        match fs::create_dir(user_dirs.images()) {
             Ok(_) => {},
             Err(_) => err_flg += 1
         }
-        match fs::create_dir(format!("{}/containers", home_injesh)) {
+        match fs::create_dir(user_dirs.containers()) {
             Ok(_) => {},
             Err(_) => err_flg += 1
         }

--- a/src/user.rs
+++ b/src/user.rs
@@ -2,7 +2,9 @@ use std::{env, fmt, error};
 
 #[derive(Debug)]
 pub struct User {
-    home: String
+    injesh_home: String,
+    images: String,
+    containers: String,
 }
 
 #[derive(Debug)]
@@ -22,17 +24,44 @@ impl error::Error for Error {}
 
 impl User {
     pub fn new() -> Result<User, Box<dyn std::error::Error>> {
-        let home = match env::var("HOME") {
-            Ok(home) => home,
+        let injesh_homedir = match env::var("HOME") {
+            Ok(home) => home + "/.injesh",
             Err(_) => return Err(Error::HomeNotFound)?
         };
 
         Ok(User{
-            home: home
+            injesh_home: format!("{}", &injesh_homedir),
+            images: format!("{}/images", &injesh_homedir),
+            containers: format!("{}/containers", &injesh_homedir)
         })
     }
 
-    pub fn home(&self) -> &str {
-        &self.home
+    pub fn injesh_home(&self) -> &str {
+        &self.injesh_home
+    }
+    pub fn images(&self) -> &str {
+        &self.images
+    }
+    pub fn containers(&self) -> &str {
+        &self.containers
+    }
+}
+
+mod tests {
+    use super::*;
+    #[test]
+    fn test_user_home() {
+        let userinfo = User::new();
+        assert_eq!(userinfo.unwrap().injesh_home(), "/home/runner/.injesh");
+    }
+    #[test]
+    fn test_user_images() {
+        let userinfo = User::new();
+        assert_eq!(userinfo.unwrap().images(), "/home/runner/.injesh/images");
+    }
+    #[test]
+    fn test_user_containers() {
+        let userinfo = User::new();
+        assert_eq!(userinfo.unwrap().containers(), "/home/runner/.injesh/containers");
     }
 }


### PR DESCRIPTION
close #17 

- homedirとの誤認を防止するため`home()`を`injesh_home()`にリネーム
- User 構造体に入れるpathを`~/.injesh`以下の3つに
  - `~/.injesh`
  - `~/.injesh/images`
  - `~/.injesh/containers`
 
- init.rsもそれに付随して変更