### PR TITLE
Feature/#23 ci docker test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-  pull_request:
 
 env:
   CARGO_INCREMENTAL: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,11 +8,6 @@ env:
   CARGO_INCREMENTAL: 1
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: cargo test
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,75 @@
+name: test
+
+on:
+  push:
+
+env:
+  CACHE_PATH_NGINX: '/tmp/nginx-image-save.tar'
+  NGINX_IMAGE_VERSION: '1.21.6'
+  CACHE_PATH_SCRATCH_WEB: '/tmp/scratch_web-image-save.tar'
+  SCRATCH_WEB_IMAGE_VERSION: 'latest'
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # cache scratch_web docker image test
+      # ------------------------------------------------
+
+      - name: Cache nginx docker image
+        id: cache-scratchweb-test2
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.CACHE_PATH_SCRATCH_WEB }}
+          key: ${{ runner.os }}-cache-scratchweb-test2-${{ env.SCRATCH_WEB_IMAGE_VERSION }}
+          restore-keys:
+            ${{ runner.os }}-cache-scratchweb-test2-
+
+      - name: Load docker image from cache
+        if: steps.cache-scratchweb-test2.outputs.cache-hit == 'true'
+        run: docker load --input ${{ env.CACHE_PATH_SCRATCH_WEB }}
+
+      - name: Build scratch web server docker image
+        if: steps.cache-scratchweb-test2.outputs.cache-hit != 'true'
+        run: |
+          docker image build -f scratch_web/Dockerfile -t scratch_web scratch_web/
+          docker save --output ${{ env.CACHE_PATH_SCRATCH_WEB }} scratch_web:${{ env.SCRATCH_WEB_IMAGE_VERSION }}
+
+      # cache nginx docker image test
+      # ------------------------------------------------
+
+      - name: Cache nginx docker image
+        id: cache-nginx-test2
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.CACHE_PATH_NGINX }}
+          key: ${{ runner.os }}-cache-nginx-test2-${{ env.NGINX_IMAGE_VERSION }}
+          restore-keys:
+            ${{ runner.os }}-cache-nginx-test2-
+
+      - name: Load docker image from cache
+        if: steps.cache-nginx-test2.outputs.cache-hit == 'true'
+        run: docker load --input ${{ env.CACHE_PATH_NGINX }}
+
+      - name: Pull docker image and save cache
+        if: steps.cache-nginx-test2.outputs.cache-hit != 'true'
+        run: |
+          docker pull nginx:${{ env.NGINX_IMAGE_VERSION }}
+          docker save --output ${{ env.CACHE_PATH_NGINX }} nginx:${{ env.NGINX_IMAGE_VERSION }}
+
+      # start docker container
+      # ------------------------------------------------
+
+      - name: run scratch_web
+        run: docker run -d --name test_scratch_web scratch_web:${{ env.SCRATCH_WEB_IMAGE_VERSION }}
+
+      - name: run nginx
+        run: docker run -d --name test_nginx nginx:${{ env.NGINX_IMAGE_VERSION }}
+
+      # run test
+      # ------------------------------------------------
+
+      - run: cargo test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Build scratch web server docker image
         if: steps.cache-scratchweb-test2.outputs.cache-hit != 'true'
         run: |
-          docker image build -f scratch_web/Dockerfile -t scratch_web scratch_web/
+          docker image build -f ci-docker/scratch_web/Dockerfile -t scratch_web ci-docker/scratch_web/
           docker save --output ${{ env.CACHE_PATH_SCRATCH_WEB }} scratch_web:${{ env.SCRATCH_WEB_IMAGE_VERSION }}
 
       # cache nginx docker image test

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ Cargo.lock
 # Added by cargo
 
 /target
+
+# for ci-docker
+
+ci-docker/target

--- a/ci-docker/scratch_web/Cargo.toml
+++ b/ci-docker/scratch_web/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "scratch_web"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ci-docker/scratch_web/Dockerfile
+++ b/ci-docker/scratch_web/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:alpine3.15 AS builder
+
+WORKDIR /scratch_web
+
+COPY Cargo.toml Cargo.toml
+COPY src/ src/
+RUN RUSTFLAGS='-C target-feature=+crt-static' cargo build
+
+# ------------------------------
+
+FROM scratch
+
+COPY --from=builder /scratch_web/target/debug/scratch_web /
+
+ENTRYPOINT ["/scratch_web"]

--- a/ci-docker/scratch_web/src/main.rs
+++ b/ci-docker/scratch_web/src/main.rs
@@ -1,0 +1,12 @@
+use std::io::prelude::*;
+use std::net::TcpListener;
+
+fn main() {
+    let listener = TcpListener::bind("127.0.0.1:7878").unwrap();
+    for stream in listener.incoming() {
+        let mut stream = stream.unwrap();
+        let mut buffer = [0; 1024];
+        stream.read(&mut buffer).unwrap();
+        stream.write(b"HTTP/1.1 200 OK\r\n\r\nHello from Server!\n").unwrap();
+    }
+}


### PR DESCRIPTION
close #23 

`cargo test`が走る前に2つのdocker container が動くようにした．
量が多めになったので，testとそれ以外とでworkflowを分けた．

- test_nginx
  - nginx. shellあり(bash).
- test_scratch_web
  - ci-docker/scratch_web/Dockerfile から作ったweb server. shellなし.

どちらもポートフォワーディングはして**いない**．